### PR TITLE
feat: add move_email and mark_as_seen tools

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,6 +319,48 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ['uid']
         }
+      },
+      {
+        name: 'move_email',
+        description: 'Move an email from one folder to another by UID. Useful for moving spam to Junk, archiving, or organizing into custom folders without losing the message.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            uid: {
+              type: 'number',
+              description: 'UID of the email to move'
+            },
+            source_folder: {
+              type: 'string',
+              description: 'Folder the email currently lives in (default: INBOX)',
+              default: 'INBOX'
+            },
+            target_folder: {
+              type: 'string',
+              description: 'Destination folder (e.g. "INBOX.Junk", "INBOX.Archive"). Use list_folders to see available folders.'
+            }
+          },
+          required: ['uid', 'target_folder']
+        }
+      },
+      {
+        name: 'mark_as_seen',
+        description: 'Mark an email as read by setting the \\Seen flag, without changing its location or content. Use for clearing unread count on legitimate-but-stale emails (newsletters, old notifications).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            uid: {
+              type: 'number',
+              description: 'UID of the email to mark as read'
+            },
+            folder: {
+              type: 'string',
+              description: 'Folder containing the email (default: INBOX)',
+              default: 'INBOX'
+            }
+          },
+          required: ['uid']
+        }
       }
     ]
   };
@@ -717,6 +759,38 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           await connection.closeBox(true); // Expunge
 
           return { content: [{ type: 'text', text: 'Email deleted successfully' }] };
+        } finally {
+          connection.end();
+        }
+      }
+
+      case 'move_email': {
+        const sourceFolder = args.source_folder || 'INBOX';
+        const targetFolder = args.target_folder;
+        if (!targetFolder) {
+          return { content: [{ type: 'text', text: 'Error: target_folder is required' }], isError: true };
+        }
+        const connection = await connectIMAP();
+
+        try {
+          await connection.openBox(sourceFolder);
+          await connection.moveMessage(args.uid, targetFolder);
+
+          return { content: [{ type: 'text', text: `Email ${args.uid} moved from "${sourceFolder}" to "${targetFolder}"` }] };
+        } finally {
+          connection.end();
+        }
+      }
+
+      case 'mark_as_seen': {
+        const folder = args.folder || 'INBOX';
+        const connection = await connectIMAP();
+
+        try {
+          await connection.openBox(folder);
+          await connection.addFlags(args.uid, ['\\Seen']);
+
+          return { content: [{ type: 'text', text: `Email ${args.uid} marked as seen in "${folder}"` }] };
         } finally {
           connection.end();
         }


### PR DESCRIPTION
## Why

The current MCP exposes `delete_email` (destructive) but no way to:

1. Move a message between folders — e.g. spam triage to `INBOX.Junk` (which trains the server-side spam filter), or organize into custom folders
2. Mark a message as read without opening it — useful for clearing the unread count on legitimate-but-stale emails (newsletters, account notifications) without losing them

Both are common workflows that currently force users out of the MCP and back to webmail.

## What

Adds two backward-compatible tools:

### `move_email(uid, source_folder='INBOX', target_folder)`
Uses imap-simple's `moveMessage()` to relocate the message. Common use:

```
move_email(uid: 668, target_folder: 'INBOX.Junk')   // spam → Junk
move_email(uid: 500, target_folder: 'INBOX.Archive') // keep but get out of inbox
```

### `mark_as_seen(uid, folder='INBOX')`
Uses imap-simple's `addFlags()` to set `\\Seen`. Non-destructive — message stays where it is.

```
mark_as_seen(uid: 432) // clear unread without opening / replying / deleting
```

## Verified

- Tested with Hostinger IMAP (folder set: INBOX, INBOX.Junk, INBOX.Trash, INBOX.Sent, INBOX.Drafts)
- `node --check index.js` passes
- Tool schemas correctly exposed via stdio `tools/list` (12 tools total after the change)

## Diff size

74 insertions, 0 deletions, 1 file (`index.js`). No new dependencies — uses imap-simple methods that are already in the bundle.

## Pairs nicely with

#5 (reply threading) — together they cover the full reply/triage workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)